### PR TITLE
fix: add explicit width and height to hero image

### DIFF
--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -10,6 +10,8 @@ import TimeLineElement from "./timeline.astro";
   class="grid lg:grid-cols-2 place-items-center pt-2 pb-8 md:pt-12 md:pb-24">
   <div class="py-6 md:order-1 md:block">
     <Picture
+      width={480}
+      height={480}
       src={heroImage}
       alt="Astronaut in the air"
       widths={[200, 400, 600]}


### PR DESCRIPTION
This eliminates the layout shift in home page